### PR TITLE
Add ability to run without config and add explicit config creation action

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,7 @@ impl KeyFunction {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
+#[serde(default)]
 pub struct Config {
     usb_vendor_id: String,
     usb_product_id: String,
@@ -160,11 +161,13 @@ impl Config {
         toml::from_str(&config_str).map_err(|e| format!("Failed to parse config file: {}", e))
     }
 
-    /// Read config file, creating default if it doesn't exist
+    /// Read config file, returning defaults if it doesn't exist
     pub async fn read(config_path: &PathBuf) -> Config {
         if !fs::try_exists(config_path).await.unwrap_or(false) {
-            Self::write_default_config(config_path).await;
+            info!("Config file not found at {}, using defaults", config_path.display());
+            return Config::default();
         }
+        info!("Loading config from: {}", config_path.display());
         let config_str = fs::read_to_string(config_path).await.unwrap();
         toml::from_str(&config_str).unwrap()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,12 @@ enum Args {
         #[arg(short, long)]
         config_path: Option<PathBuf>,
     },
+    /// Create default config file
+    CreateConfig {
+        /// Path to the config file, defaults to /etc/zenbook-duo-daemon/config.toml
+        #[arg(short, long)]
+        config_path: Option<PathBuf>,
+    },
 }
 
 mod config;
@@ -58,6 +64,12 @@ async fn main() {
     match args {
         Args::MigrateConfig { config_path } => {
             migrate_config(config_path.unwrap_or(PathBuf::from(DEFAULT_CONFIG_PATH))).await;
+            return;
+        }
+        Args::CreateConfig { config_path } => {
+            let config_path = config_path.unwrap_or(PathBuf::from(DEFAULT_CONFIG_PATH));
+            Config::write_default_config(&config_path).await;
+            info!("Created default config file at: {}", config_path.display());
             return;
         }
         Args::Run { config_path } => {


### PR DESCRIPTION
this serves three purposes:

1) by running the daemon, the filesystem is not being littered by automatically created config file. it's quite usual to ship (default) config files as a part of distribution package, not creating it during runtime. to keep the functionality, i've added the create-config action.

2) it's actually now possible to run the daemon without any config at all if you're happy with the defaults.

3) it's now possible to only specify some keys in the config. this is most useful if you only want to override some defaults. as a side effect, the daemon now does not crash when you don't migrate the config.