### PR TITLE
Keyboard backlight and mic mute LED over Bluetooth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ evdev-rs = { version = "0.6.3", features = ["serde"] }
 futures = "0.3.31"
 inotify = { version = "0.11.0", features = ["stream"] }
 log = "0.4.29"
-nix = { version = "0.30.1", features = ["fs"] }
+nix = { version = "0.30.1", features = ["fs", "ioctl"] }
 nusb = { version = "0.2.1", features = ["tokio"] }
 pulseaudio = "0.3.1"
 serde = { version = "1.0.228", features = ["alloc"] }

--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ AI Generated Wiki: [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://dee
 | Volume Down Key                 | ✅         | ✅             | `KEY_VOLUMEDOWN`             | ❌                          |
 | Volume Up Key                   | ✅         | ✅             | `KEY_VOLUMEUP`               | ❌                          |
 | Keyboard Backlight Key          | ✅         | ✅             | `KEY_BACKLIGHT`              | ✅                          |
-| Keyboard Backlight Control      | ✅         | ❌ (1)         | N/A                          | ✅                          |
+| Keyboard Backlight Control      | ✅         | ✅             | N/A                          | ✅                          |
 | Brightness Down Key             | ✅         | ✅             | `KEY_BRIGHTNESSDOWN`         | ✅                          |
 | Brightness Up Key               | ✅         | ✅             | `KEY_BRIGHTNESSUP`           | ✅                          |
 | Extended Display Mode Key       | ✅         | ✅             | `KEY_LEFT_META + KEY_P`      | ❌                          |
 | Swap Up Down Display Key        | ✅         | ✅             | None                         | ✅                          |
 | Microphone Mute Key             | ✅         | ✅             | `KEY_MICMUTE`                | ✅                          |
-| Microphone Mute Key LED Control | ✅         | ❌ (2)         | N/A                          | ✅                          |
+| Microphone Mute Key LED Control | ✅         | ✅             | N/A                          | ✅                          |
 | Emoji Picker Key                | ✅         | ✅             | `KEY_LEFTCTRL + KEY_DOT` (3) | ✅                          |
 | MyASUS Key                      | ✅         | ✅             | None                         | ✅                          |
 | Toggle Secondary Display Key    | ✅         | ✅             | Toggle Secondary Display     | ✅                          |
 | Fn + Function Keys              | ✅         | ✅             | F1 - F12                     | ❌                          |
 
-1. Should be possible, the packet capture file under windows is at `pcap/bt_change_backlight.pcapng`
-2. Should be possible, the packet capture file under windows is at `pcap/bt_micmute_led.pcapng`
+1. Sent as the wired vendor feature report over the Bluetooth hidraw node, see `src/hidraw.rs`
+2. Sent the same way as the backlight, see `src/hidraw.rs`
 3. This key combination only works for GTK apps in GNOME.
 
 ## Installation

--- a/src/hidraw.rs
+++ b/src/hidraw.rs
@@ -1,0 +1,122 @@
+//! Keyboard backlight and mic mute LED over Bluetooth.
+//!
+//! The keyboard accepts the same vendor HID feature reports over Bluetooth as it does
+//! over USB, so the payloads here are the ones `keyboard_usb` already sends. Only the
+//! transport differs: an HIDIOCSFEATURE ioctl on the Bluetooth hidraw node instead of a
+//! USB control transfer.
+
+use std::fs;
+use std::os::fd::AsRawFd as _;
+use std::path::PathBuf;
+
+use log::{debug, warn};
+
+use crate::parse_hex_string;
+use crate::state::KeyboardBacklightState;
+
+// HIDIOCSFEATURE(len) = _IOC(READ | WRITE, 'H', 0x06, len)
+nix::ioctl_readwrite_buf!(hid_set_feature, b'H', 0x06, u8);
+
+/// Bluetooth bus, hid-generic keyboard interface, ASUS vendor. The sibling `g0004` node
+/// is the touchpad and ignores these reports. The product id is deliberately not part of
+/// the match: it differs per model (`1b2d` on the 2024, `1bf3` on the 2025) and no other
+/// ASUS Bluetooth keyboard interface turns up on this machine.
+const MODALIAS_PREFIX: &str = "hid:b0005g0001v00000B05";
+
+/// Resolved on every write rather than cached, because hidraw node numbers are handed
+/// out in connection order and change when the keyboard reconnects.
+fn find_bt_hidraw() -> Option<PathBuf> {
+    for entry in fs::read_dir("/sys/class/hidraw").ok()?.flatten() {
+        let modalias = fs::read_to_string(entry.path().join("device/modalias")).unwrap_or_default();
+        if modalias.trim().starts_with(MODALIAS_PREFIX) {
+            return Some(PathBuf::from("/dev").join(entry.file_name()));
+        }
+    }
+    None
+}
+
+fn send_feature_report(hex: &str, what: &str) {
+    let Some(node) = find_bt_hidraw() else {
+        debug!("No Bluetooth keyboard hidraw node, skipping {what}");
+        return;
+    };
+
+    let file = match fs::OpenOptions::new().read(true).write(true).open(&node) {
+        Ok(file) => file,
+        Err(e) => {
+            warn!("Failed to open {} for {}: {}", node.display(), what, e);
+            return;
+        }
+    };
+
+    let mut data = parse_hex_string(hex);
+    // SAFETY: HIDIOCSFEATURE reads data.len() bytes out of a buffer we own, and the
+    // length is encoded into the request number by the ioctl_readwrite_buf macro.
+    match unsafe { hid_set_feature(file.as_raw_fd(), &mut data) } {
+        Ok(_) => debug!("Sent {} over Bluetooth on {}", what, node.display()),
+        Err(e) => warn!("Failed to send {} over Bluetooth: {}", what, e),
+    }
+}
+
+fn backlight_report(state: KeyboardBacklightState) -> &'static str {
+    match state {
+        KeyboardBacklightState::Off => "5abac5c4000000000000000000000000",
+        KeyboardBacklightState::Low => "5abac5c4010000000000000000000000",
+        KeyboardBacklightState::Medium => "5abac5c4020000000000000000000000",
+        KeyboardBacklightState::High => "5abac5c4030000000000000000000000",
+    }
+}
+
+fn mic_mute_report(enabled: bool) -> &'static str {
+    if enabled {
+        "5ad07c01000000000000000000000000"
+    } else {
+        "5ad07c00000000000000000000000000"
+    }
+}
+
+pub fn send_backlight_state(state: KeyboardBacklightState) {
+    send_feature_report(backlight_report(state), "backlight state");
+}
+
+pub fn send_mic_mute_state(enabled: bool) {
+    send_feature_report(mic_mute_report(enabled), "mic mute state");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reports are hand written hex, and a typo in one of them is silent: the ioctl
+    /// still succeeds, the keyboard just ignores it.
+    #[test]
+    fn reports_are_16_byte_frames_carrying_the_right_level() {
+        let cases = [
+            (KeyboardBacklightState::Off, 0),
+            (KeyboardBacklightState::Low, 1),
+            (KeyboardBacklightState::Medium, 2),
+            (KeyboardBacklightState::High, 3),
+        ];
+        for (state, level) in cases {
+            let report = parse_hex_string(backlight_report(state));
+            assert_eq!(report.len(), 16, "{state:?} report is not 16 bytes");
+            assert_eq!(
+                report[..4],
+                [0x5a, 0xba, 0xc5, 0xc4],
+                "{state:?} wrong prefix"
+            );
+            assert_eq!(report[4], level, "{state:?} wrong level byte");
+            assert!(
+                report[5..].iter().all(|b| *b == 0),
+                "{state:?} dirty padding"
+            );
+        }
+
+        for (enabled, expected) in [(true, 1), (false, 0)] {
+            let report = parse_hex_string(mic_mute_report(enabled));
+            assert_eq!(report.len(), 16);
+            assert_eq!(report[..3], [0x5a, 0xd0, 0x7c]);
+            assert_eq!(report[3], expected);
+        }
+    }
+}

--- a/src/keyboard_bt.rs
+++ b/src/keyboard_bt.rs
@@ -12,8 +12,8 @@ use tokio::sync::{Mutex, broadcast};
 use tokio::{fs, task::spawn_blocking};
 
 use crate::{
-    config::Config, events::Event, idle_detection::ActivityNotifier, state::KeyboardStateManager,
-    virtual_keyboard::VirtualKeyboard,
+    config::Config, events::Event, hidraw, idle_detection::ActivityNotifier,
+    state::KeyboardStateManager, virtual_keyboard::VirtualKeyboard,
 };
 
 pub fn start_bt_keyboard_monitor_task(
@@ -145,6 +145,14 @@ pub fn start_bt_keyboard_task(
     info!("Bluetooth connected on {}", path.display());
     activity_notifier.notify();
 
+    // The keyboard comes back with whatever its firmware last had, so push the state we
+    // think it should be in.
+    // ponytail: one keyboard shows up as several /dev/input event nodes, so this task is
+    // started once per node and these reports go out two or three times over. They are
+    // idempotent and rare; dedupe or move the writes to a single task if it ever matters.
+    hidraw::send_backlight_state(state_manager.get_keyboard_backlight());
+    hidraw::send_mic_mute_state(state_manager.get_mic_mute_led());
+
     // Create a cancellation token for the control task
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
@@ -158,11 +166,11 @@ pub fn start_bt_keyboard_task(
                 }
                 result = event_receiver.recv() => {
                     match result {
-                        Ok(Event::Backlight(_state)) => {
-                            // TODO: send to keyboard device
+                        Ok(Event::Backlight(state)) => {
+                            hidraw::send_backlight_state(state);
                         }
-                        Ok(Event::MicMuteLed(_enabled)) => {
-                            // TODO: send to keyboard device
+                        Ok(Event::MicMuteLed(enabled)) => {
+                            hidraw::send_mic_mute_state(enabled);
                         }
                         Ok(_) => {
                             // dont care about other events

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ enum Args {
 
 mod config;
 mod events;
+mod hidraw;
 mod idle_detection;
 mod keyboard_bt;
 mod keyboard_usb;


### PR DESCRIPTION
Implements what #8 describes, and closes #6.

The keyboard accepts the **same vendor HID feature report over Bluetooth as it does over USB**, so no new protocol is needed. The payloads here are byte-identical to the ones `keyboard_usb.rs` already sends; only the transport differs — an `HIDIOCSFEATURE` ioctl on the Bluetooth hidraw node instead of a USB control transfer.

This fills in the two `// TODO: send to keyboard device` stubs in the Bluetooth control task, and flips both ❌ rows in the README feature table.

### Implementation notes

- **No new dependency.** `nix` is already in the tree and just needed its `ioctl` feature; `ioctl_readwrite_buf!(hid_set_feature, b'H', 0x06, u8)` generates exactly the request `#8` computes by hand as `0xC0004806 | (len << 16)`.
- **The node is matched on its modalias, not a fixed `/dev/hidrawN`**, because hidraw numbering follows connection order and changes when the keyboard reconnects. It is resolved per write rather than cached, for the same reason.
- **The product id is deliberately left out of the match** (`hid:b0005g0001v00000B05`). It differs per model — `1b2d` on the 2024, `1bf3` on the 2025 — and no other ASUS Bluetooth keyboard interface shows up on this hardware. The `g0004` sibling is the touchpad and ignores these reports.
- Current LED state is pushed on Bluetooth connect, since the keyboard comes back with whatever its firmware last had.
- There is a unit test over the report payloads. They are hand-written hex, and a typo in one is otherwise silent: the ioctl still succeeds and the keyboard simply ignores the report.

### Testing

Verified by hand on a **UX8406CA (2025)** — the backlight visibly responds to all four levels. #8 reported the same feature report working on a **UX8406MA (2024)**, so this looks consistent across both generations.

The mic mute LED path is the same transport and the same wired payload, but I have only exercised the backlight on real hardware.

### Known limitation

One keyboard shows up as several `/dev/input` event nodes, so the Bluetooth control task is started once per node and these reports go out two or three times over. They are idempotent and the events are rare, so I left it alone rather than adding coordination — happy to dedupe or move the writes to a single task if you would prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
